### PR TITLE
Fixed issue with replacing the config array with a string

### DIFF
--- a/src/Inviter.php
+++ b/src/Inviter.php
@@ -26,7 +26,8 @@ class Inviter {
         $this->_captcha = new \ReCaptcha\ReCaptcha($this->_config['recaptcha']['secret']);
 
         // domain compatibility fixing
-        $this->_config = _fixDomain($config['domain']);
+        $this->_config['domain'] = $this->_fixDomain($config['domain']);
+
     }
 
     /**


### PR DESCRIPTION
Hey @fateyan. I just deployed this for a new slack team. Thanks for making inviting easy :)

I found an error through, in which the config array was assigned the string of the subdomain. This PR fixes the issue.

Cheers!
Ben
